### PR TITLE
Configurable URL for recaptcha

### DIFF
--- a/captcha/client.py
+++ b/captcha/client.py
@@ -21,6 +21,10 @@ API_SERVER = getattr(settings, "CAPTCHA_API_SERVER", DEFAULT_API_SERVER)
 VERIFY_SERVER = getattr(settings, "CAPTCHA_VERIFY_SERVER",
                         DEFAULT_VERIFY_SERVER)
 
+ASYNC = getattr(settings, "CAPTCHA_ASYNC", False)
+DEFER = getattr(settings, "CAPTCHA_DEFER", False)
+
+
 if getattr(settings, "CAPTCHA_AJAX", False):
     WIDGET_TEMPLATE = getattr(settings, "CAPTCHA_WIDGET_TEMPLATE",
                               DEFAULT_WIDGET_TEMPLATE_AJAX)

--- a/captcha/templates/captcha/widget.html
+++ b/captcha/templates/captcha/widget.html
@@ -8,7 +8,7 @@
         }
     }
 </script>
-<script type="text/javascript" src="{{api_server}}/challenge?k={{ public_key }}&hl={{ lang }}"></script>
+<script type="text/javascript" src="{{api_server}}/challenge?k={{ public_key }}&hl={{ lang }}"{% if async %} async{%endif %}{% if defer %} defer{% endif %}></script>
 <noscript>
   <iframe src="{{ api_server }}/noscript?k={{ public_key }}&hl={{ lang }}" height="300" width="500" frameborder="0"></iframe><br />
   <textarea name="recaptcha_challenge_field" rows="3" cols="40"></textarea>

--- a/captcha/templates/captcha/widget_nocaptcha.html
+++ b/captcha/templates/captcha/widget_nocaptcha.html
@@ -1,4 +1,4 @@
-<script src="{{api_server}}.js{% if lang %}?hl={{ lang }}{% endif %}"></script>
+<script src="{{api_server}}.js{% if lang %}?hl={{ lang }}{% endif %}"{% if async %} async{%endif %}{% if defer %} defer{% endif %}></script>
 <div class="g-recaptcha" data-sitekey="{{ public_key }}" {% for option,value in widget.attrs.items %}data-{{ option }}="{{ value }}" {% endfor %}></div>
 <noscript>
   <div style="width: 302px; height: 352px;">

--- a/captcha/templates/captcha/widget_nocaptcha.html
+++ b/captcha/templates/captcha/widget_nocaptcha.html
@@ -1,10 +1,10 @@
-<script src="https://www.google.com/recaptcha/api.js{% if lang %}?hl={{ lang }}{% endif %}"></script>
+<script src="{{api_server}}.js{% if lang %}?hl={{ lang }}{% endif %}"></script>
 <div class="g-recaptcha" data-sitekey="{{ public_key }}" {% for option,value in widget.attrs.items %}data-{{ option }}="{{ value }}" {% endfor %}></div>
 <noscript>
   <div style="width: 302px; height: 352px;">
     <div style="width: 302px; height: 352px; position: relative;">
       <div style="width: 302px; height: 352px; position: absolute;">
-        <iframe src="https://www.google.com/recaptcha/api/fallback?k={{ public_key }}"
+        <iframe src="{{api_server}}/fallback?k={{ public_key }}"
                 frameborder="0" scrolling="no"
                 style="width: 302px; height:352px; border-style: none;">
         </iframe>

--- a/captcha/widgets.py
+++ b/captcha/widgets.py
@@ -5,7 +5,7 @@ from django.conf import settings
 from django.utils.safestring import mark_safe
 from django.utils.translation import get_language
 
-from .client import API_SERVER, WIDGET_TEMPLATE
+from .client import API_SERVER, ASYNC, DEFER, WIDGET_TEMPLATE
 
 
 class ReCaptcha(forms.widgets.Widget):
@@ -45,6 +45,8 @@ class ReCaptcha(forms.widgets.Widget):
                 }
             }
         context.update({
+            'async': ASYNC,
+            'defer': DEFER,
             'api_server': API_SERVER,
             'public_key': self.public_key,
             'lang': lang,


### PR DESCRIPTION
In some templates, https://www.google.com is a hardcoded URL. However, this URL is unaccessible in some countries with Internet censorship, most notably China. Luckily, Google offers an alternative URL, https://www.recaptcha.net, which is intended to work globally. 

From Google documentation:
https://developers.google.com/recaptcha/docs/faq#can-i-use-recaptcha-globally

Recaptcha issues in China (just for reference):
https://github.com/google/recaptcha/issues/87
Initially, they discuss reverse-proxy solution to the problem, but recaptcha.net comes up later.

At the moment, django-recaptcha users cannot alter recaptcha URL from settings. This pull request makes this URL configurable - you simply need to alter an already existing CAPTCHA_API_SERVER variable in your configuration, and templates will pick it up as {{api_server}} context variable.

There is one case where I should have probably created a separate variable. In ``widget_nocaptcha.html``, there was https://www.google.com/recaptcha/api.js. I turned this into 

```
{{ api_request }}.js
```

Which works, but it is probably not the best idea to have both ``/recaptcha/api.js`` and ``/recaptcha/api/`` generated from the same variable since these URLs are used for different purposes.

Another addition is CAPTCHA_ASYNC and CAPTCHA_DEFER variables. Original templates used neither async nor defer, and this prevents page from fully rendering unless recaptcha scripts are downloaded by browser. This is especially noticeable in China, where recaptcha scripts served from google.com are not exactly banned, but are throttled to such a low speed that your site has almost no chances of rendering anything below captcha. In this particular case, CAPTCHA_DEFER would allow you to render the whole template and postpone scripts until later, but I allowed to configure defer and async individually, since everyone has their own project requirements.