### PR TITLE
Implements support for when `Verify the origin of reCAPTCHA solution is unchecked.

### DIFF
--- a/AUTHORS.rst
+++ b/AUTHORS.rst
@@ -32,3 +32,4 @@ Other
 * `Alexey Subbotin <https://github.com/dotsbb>`_
 * `Sean Stewart <https://github.com/mindcruzer>`_
 * `Rob Charlwood <https://github.com/robcharlwood>`_
+* `Ryan Sullivan <https://github.com/rgs258>`_

--- a/README.rst
+++ b/README.rst
@@ -73,6 +73,18 @@ Installation
 
 This will change the Google JavaScript api domain as well as the client side field verification domain.
 
+#. (OPTIONAL) When `Verify the origin of reCAPTCHA solutions` is unchecked in the reCaptcha settings, then you are required to check the hostname on your server  verifying a solution as per the `reCAPTCHA Domain/Package Name Validation <https://developers.google.com/recaptcha/docs/domain_validation>`_. Set the RECAPTCHA_VALIDATE_HOSTNAME to a function that takes a str and returns True when when the domain is expected:
+
+    .. code-block:: python
+
+        def validate_hostname(hostname):
+            return re.compile("^.*\.valid\.com$").match(hostname)
+
+        RECAPTCHA_VALIDATE_HOSTNAME = validate_hostname
+
+    This will change the Google JavaScript api domain as well as the client side field verification domain.
+
+
 Usage
 -----
 

--- a/captcha/fields.py
+++ b/captcha/fields.py
@@ -94,8 +94,7 @@ class ReCaptchaField(forms.CharField):
                     % hostname
                 )
                 raise ValidationError(
-                    self.error_messages["captcha_invalid"],
-                    code="captcha_invalid"
+                    self.error_messages["captcha_invalid"], code="captcha_invalid"
                 )
 
         required_score = self.widget.attrs.get("required_score")

--- a/captcha/fields.py
+++ b/captcha/fields.py
@@ -85,6 +85,19 @@ class ReCaptchaField(forms.CharField):
                 self.error_messages["captcha_invalid"], code="captcha_invalid"
             )
 
+        validate_hostname = self.widget.attrs.get("validate_hostname")
+        if validate_hostname:
+            hostname = check_captcha.extra_data.get("hostname")
+            if not validate_hostname(hostname):
+                logger.error(
+                    "ReCAPTCHA validation failed because hostname %s rejected"
+                    % hostname
+                )
+                raise ValidationError(
+                    self.error_messages["captcha_invalid"],
+                    code="captcha_invalid"
+                )
+
         required_score = self.widget.attrs.get("required_score")
         if required_score:
             # Our score values need to be floats, as that is the expected

--- a/captcha/tests/test_fields.py
+++ b/captcha/tests/test_fields.py
@@ -21,7 +21,7 @@ def validate_hostname(hostname):
     :param hostname: a str that is a hostname that should match the pattern
     :return: True if the hostname matches the pattern
     """
-    pattern = "^.*\.valid\.com$"
+    pattern = r"^.*\.valid\.com$"
     return re.compile(pattern).match(hostname)
 
 

--- a/captcha/tests/test_fields.py
+++ b/captcha/tests/test_fields.py
@@ -1,5 +1,4 @@
 import re
-
 from unittest.mock import MagicMock, PropertyMock, patch
 from urllib.error import HTTPError
 
@@ -99,8 +98,7 @@ class TestFields(TestCase):
     @patch("captcha.fields.client.submit")
     def test_validate_hostname_success_using_attr(self, mocked_submit):
         mocked_submit.return_value = RecaptchaResponse(
-            is_valid=True,
-            extra_data={'hostname': 'example.valid.com'}
+            is_valid=True, extra_data={"hostname": "example.valid.com"}
         )
         form_params = {"g-recaptcha-response": "PASSED"}
 
@@ -120,15 +118,12 @@ class TestFields(TestCase):
     @override_settings(RECAPTCHA_VALIDATE_HOSTNAME=validate_hostname)
     def test_validate_hostname_success(self, mocked_submit):
         mocked_submit.return_value = RecaptchaResponse(
-            is_valid=True,
-            extra_data={'hostname': 'example.valid.com'}
+            is_valid=True, extra_data={"hostname": "example.valid.com"}
         )
         form_params = {"g-recaptcha-response": "PASSED"}
 
         class HostnameForm(forms.Form):
-            captcha = fields.ReCaptchaField(
-                widget=widgets.ReCaptchaBase()
-            )
+            captcha = fields.ReCaptchaField(widget=widgets.ReCaptchaBase())
 
         form = HostnameForm(form_params)
         self.assertTrue(form.is_valid())
@@ -137,15 +132,12 @@ class TestFields(TestCase):
     @override_settings(RECAPTCHA_VALIDATE_HOSTNAME=validate_hostname)
     def test_validate_hostname_failure(self, mocked_submit):
         mocked_submit.return_value = RecaptchaResponse(
-            is_valid=True,
-            extra_data={'hostname': 'example.invalid.com'}
+            is_valid=True, extra_data={"hostname": "example.invalid.com"}
         )
         form_params = {"g-recaptcha-response": "PASSED"}
 
         class HostnameForm(forms.Form):
-            captcha = fields.ReCaptchaField(
-                widget=widgets.ReCaptchaBase()
-            )
+            captcha = fields.ReCaptchaField(widget=widgets.ReCaptchaBase())
 
         form = HostnameForm(form_params)
         self.assertFalse(form.is_valid())

--- a/captcha/tests/test_fields.py
+++ b/captcha/tests/test_fields.py
@@ -1,3 +1,5 @@
+import re
+
 from unittest.mock import MagicMock, PropertyMock, patch
 from urllib.error import HTTPError
 
@@ -11,6 +13,16 @@ from captcha.client import RecaptchaResponse
 
 class DefaultForm(forms.Form):
     captcha = fields.ReCaptchaField()
+
+
+def validate_hostname(hostname):
+    """
+    Validates a hostname against a pattern
+    :param hostname: a str that is a hostname that should match the pattern
+    :return: True if the hostname matches the pattern
+    """
+    pattern = "^.*\.valid\.com$"
+    return re.compile(pattern).match(hostname)
 
 
 class TestFields(TestCase):
@@ -83,6 +95,60 @@ class TestFields(TestCase):
         self.assertEqual(
             form.errors["captcha"], ["Error verifying reCAPTCHA, please try again."]
         )
+
+    @patch("captcha.fields.client.submit")
+    def test_validate_hostname_success_using_attr(self, mocked_submit):
+        mocked_submit.return_value = RecaptchaResponse(
+            is_valid=True,
+            extra_data={'hostname': 'example.valid.com'}
+        )
+        form_params = {"g-recaptcha-response": "PASSED"}
+
+        class HostnameForm(forms.Form):
+            captcha = fields.ReCaptchaField(
+                widget=widgets.ReCaptchaBase(
+                    attrs={
+                        "validate_hostname": validate_hostname,
+                    },
+                )
+            )
+
+        form = HostnameForm(form_params)
+        self.assertTrue(form.is_valid())
+
+    @patch("captcha.fields.client.submit")
+    @override_settings(RECAPTCHA_VALIDATE_HOSTNAME=validate_hostname)
+    def test_validate_hostname_success(self, mocked_submit):
+        mocked_submit.return_value = RecaptchaResponse(
+            is_valid=True,
+            extra_data={'hostname': 'example.valid.com'}
+        )
+        form_params = {"g-recaptcha-response": "PASSED"}
+
+        class HostnameForm(forms.Form):
+            captcha = fields.ReCaptchaField(
+                widget=widgets.ReCaptchaBase()
+            )
+
+        form = HostnameForm(form_params)
+        self.assertTrue(form.is_valid())
+
+    @patch("captcha.fields.client.submit")
+    @override_settings(RECAPTCHA_VALIDATE_HOSTNAME=validate_hostname)
+    def test_validate_hostname_failure(self, mocked_submit):
+        mocked_submit.return_value = RecaptchaResponse(
+            is_valid=True,
+            extra_data={'hostname': 'example.invalid.com'}
+        )
+        form_params = {"g-recaptcha-response": "PASSED"}
+
+        class HostnameForm(forms.Form):
+            captcha = fields.ReCaptchaField(
+                widget=widgets.ReCaptchaBase()
+            )
+
+        form = HostnameForm(form_params)
+        self.assertFalse(form.is_valid())
 
 
 class TestWidgets(TestCase):

--- a/captcha/widgets.py
+++ b/captcha/widgets.py
@@ -22,6 +22,11 @@ class ReCaptchaBase(widgets.Widget):
         self.uuid = uuid.uuid4().hex
         self.api_params = api_params or {}
 
+        if not self.attrs.get("validate_hostname", None):
+            self.attrs["validate_hostname"] = getattr(
+                settings, "RECAPTCHA_VALIDATE_HOSTNAME", None
+            )
+
     def value_from_datadict(self, data, files, name):
         return data.get(self.recaptcha_response_name, None)
 


### PR DESCRIPTION
Implements support for when `Verify the origin of reCAPTCHA solution is unchecked in the reCaptcha settings by adding support for verifying a solution as per the [reCAPTCHA Domain/Package Name Validation](https://developers.google.com/recaptcha/docs/domain_validation).