### PR TITLE
Remove use of deprecated function.

### DIFF
--- a/captcha/fields.py
+++ b/captcha/fields.py
@@ -9,7 +9,7 @@ from django.conf import settings
 from django.core.exceptions import ImproperlyConfigured
 from django.core.exceptions import ValidationError
 from django.utils.encoding import force_text
-from django.utils.translation import ugettext_lazy as _
+from django.utils.translation import gettext_lazy as _
 
 from captcha import client
 from captcha._compat import HTTPError, urlencode


### PR DESCRIPTION
`django.utils.translation.ugettext_lazy()` is deprecated in favor of` django.utils.translation.gettext_lazy()` and will be removed in Django 4.0