### PR TITLE
Move class to widget

### DIFF
--- a/AUTHORS.rst
+++ b/AUTHORS.rst
@@ -27,3 +27,4 @@ Other
 * `Alexey Subbotin <https://github.com/dotsbb>`_
 * `Sean Stewart <https://github.com/mindcruzer>`_
 * `Rob Charlwood <https://github.com/robcharlwood>`_
+* `Ryan Sullivan <https://github.com/rgs258>`_

--- a/README.rst
+++ b/README.rst
@@ -77,6 +77,18 @@ Installation
 
 This will change the Google JavaScript api domain as well as the client side field verification domain.
 
+#. (OPTIONAL) When `Verify the origin of reCAPTCHA solutions` is unchecked in the reCaptcha settings, then you are required to check the hostname on your server  verifying a solution as per the `reCAPTCHA Domain/Package Name Validation <https://developers.google.com/recaptcha/docs/domain_validation>`_. Set the RECAPTCHA_VALIDATE_HOSTNAME to a function that takes a str and returns True when when the domain is expected:
+
+    .. code-block:: python
+
+        def validate_hostname(hostname):
+            return re.compile("^.*\.valid\.com$").match(hostname)
+
+        RECAPTCHA_VALIDATE_HOSTNAME = validate_hostname
+
+    This will change the Google JavaScript api domain as well as the client side field verification domain.
+
+
 Usage
 -----
 

--- a/captcha/fields.py
+++ b/captcha/fields.py
@@ -92,6 +92,19 @@ class ReCaptchaField(forms.CharField):
                 code="captcha_invalid"
             )
 
+        validate_hostname = self.widget.attrs.get("validate_hostname")
+        if validate_hostname:
+            hostname = check_captcha.extra_data.get("hostname")
+            if not validate_hostname(hostname):
+                logger.error(
+                    "ReCAPTCHA validation failed because hostname %s rejected"
+                    % hostname
+                )
+                raise ValidationError(
+                    self.error_messages["captcha_invalid"],
+                    code="captcha_invalid"
+                )
+
         required_score = self.widget.attrs.get("required_score")
         if required_score:
             # Our score values need to be floats, as that is the expected

--- a/captcha/templates/captcha/widget_v2_checkbox.html
+++ b/captcha/templates/captcha/widget_v2_checkbox.html
@@ -1,5 +1,5 @@
 {% include "captcha/includes/js_v2_checkbox.html" %}
-<div class="g-recaptcha"
+<div
     {% for name, value in widget.attrs.items %}{% if value is not False %} {{ name }}{% if value is not True %}="{{ value|stringformat:'s' }}"{% endif %}{% endif %}{% endfor %}
 >
 </div>

--- a/captcha/templates/captcha/widget_v2_invisible.html
+++ b/captcha/templates/captcha/widget_v2_invisible.html
@@ -1,5 +1,5 @@
 {% include "captcha/includes/js_v2_invisible.html" %}
-<div class="g-recaptcha"
+<div
     {% for name, value in widget.attrs.items %}{% if value is not False %} {{ name }}{% if value is not True %}="{{ value|stringformat:'s' }}"{% endif %}{% endif %}{% endfor %}
 >
 </div>

--- a/captcha/templates/captcha/widget_v3.html
+++ b/captcha/templates/captcha/widget_v3.html
@@ -1,5 +1,5 @@
 {% include "captcha/includes/js_v3.html" %}
-<input class="g-recaptcha"
+<input
     type="hidden"
     name="{{ widget.name }}"
     {% for name, value in widget.attrs.items %}{% if value is not False %} {{ name }}{% if value is not True %}="{{ value|stringformat:'s' }}"{% endif %}{% endif %}{% endfor %}

--- a/captcha/tests/test_fields.py
+++ b/captcha/tests/test_fields.py
@@ -27,7 +27,7 @@ def validate_hostname(hostname):
     :param hostname: a str that is a hostname that should match the pattern
     :return: True if the hostname matches the pattern
     """
-    pattern = "^.*\.valid\.com$"
+    pattern = r"^.*\.valid\.com$"
     return re.compile(pattern).match(hostname)
 
 

--- a/captcha/widgets.py
+++ b/captcha/widgets.py
@@ -28,6 +28,9 @@ class ReCaptchaBase(widgets.Widget):
             self.attrs["validate_hostname"] = getattr(
                 settings, "RECAPTCHA_VALIDATE_HOSTNAME", None
             )
+        if not self.attrs.get("class", None):
+            self.attrs["class"] = "g-recaptcha"
+
 
     def value_from_datadict(self, data, files, name):
         return data.get(self.recaptcha_response_name, None)

--- a/captcha/widgets.py
+++ b/captcha/widgets.py
@@ -24,6 +24,11 @@ class ReCaptchaBase(widgets.Widget):
         self.uuid = uuid.uuid4().hex
         self.api_params = api_params or {}
 
+        if not self.attrs.get("validate_hostname", None):
+            self.attrs["validate_hostname"] = getattr(
+                settings, "RECAPTCHA_VALIDATE_HOSTNAME", None
+            )
+
     def value_from_datadict(self, data, files, name):
         return data.get(self.recaptcha_response_name, None)
 


### PR DESCRIPTION
The bootstrap_form tag in the popular django-bootstrap4 package will add a form-control class to the div of a form field. With a hard coded class in the templates, this results in two class attributes which is not allowed.

This change moves the class to the widget. This allows the widget to do all the class inserting and avoid creating duplicate class attributes on the div.