### PR TITLE
Fix additional "paramater" typo in README.

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -154,7 +154,7 @@ widget, containing a dictionary of options. For example:
 
 The reCAPTCHA api supports several `parameters
 <https://developers.google.com/recaptcha/docs/display#js_param>`_. To customise
-the parameters that get sent along pass an ``api_params`` paramater to the
+the parameters that get sent along pass an ``api_params`` parameter to the
 widget, containing a dictionary of options. For example:
 
 .. code-block:: python


### PR DESCRIPTION
Change misspelled word "paramater" to "parameter". This is the same misspelling (and the same sentence) as in #207.