### PR TITLE
RemovedInDjango41Warning: 'captcha' defines default_app_config = 'captcha.apps.CaptchaConfig'.

### DIFF
--- a/captcha/__init__.py
+++ b/captcha/__init__.py
@@ -1,3 +1,4 @@
+import django
 from django.conf import settings
 from django.core.exceptions import ImproperlyConfigured
 
@@ -18,4 +19,5 @@ for variable, instance_type in SETTINGS_TYPES.items():
             "Setting %s is not of type" % variable, instance_type
         )
 
-default_app_config = "captcha.apps.CaptchaConfig"
+if django.VERSION < (3, 2):
+    default_app_config = "captcha.apps.CaptchaConfig"


### PR DESCRIPTION
default_app_config is deprecated when a single AppConfig subclass exists in apps.py as per [3.2 release notes](https://docs.djangoproject.com/en/3.2/releases/3.2/#automatic-appconfig-discovery)