### PR TITLE
Prepare 3.0 release

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -4,6 +4,12 @@ Changelog
 Unreleased
 ----------
 
+Nothing new yet!
+
+3.0.0 (2022-02-07)
+--------------------
+#. Torchbox has taken over maintenance of this package from Praekelt. See the `Github Announcement <https://github.com/torchbox/django-recaptcha/discussions/249>`_
+#. Switch testing from Travis to Github Actions.
 #. Only provide default_app_config for django.VERSIONs lower than 3.2
 #. Changed log level of check failures from error to warning.
 #. Added testing for Django 3.2 and 4.0

--- a/setup.py
+++ b/setup.py
@@ -10,7 +10,7 @@ long_desc = (
 
 setup(
     name="django-recaptcha",
-    version="2.1.0",
+    version="3.0.0",
     description="Django recaptcha form field/widget app.",
     long_description=long_desc,
     long_description_content_type="text/x-rst",

--- a/setup.py
+++ b/setup.py
@@ -18,6 +18,11 @@ setup(
     author_email="dev@praekelt.com",
     license="BSD",
     url="https://github.com/torchbox/django-recaptcha",
+    project_urls={
+        "Changelog": "https://github.com/torchbox/django-recaptcha/blob/main/CHANGELOG.rst",
+        "Issue Tracker": "https://github.com/torchbox/django-recaptcha/issues",
+        "Discussions": "https://github.com/torchbox/django-recaptcha/discussions",
+    },
     packages=find_packages(),
     install_requires=["django"],
     keywords=["django", "reCAPTCHA", "reCAPTCHA v2", "reCAPTCHA v3"],


### PR DESCRIPTION
We've added support for Django 4.0 but haven't made a release yet. When we do, https://github.com/torchbox/django-recaptcha/issues/269 is fixed.

Because we are dropping support for older Python and Django versions (a backwards-incompatible change) it is best to create a new major release following [SemVer](https://semver.org/) conventions.

cc co-maintainers

- @tbrlpld
- @thibaudcolas 
- @atodorov
- @rgs258
- @Andrew-Chen-Wang