### PR TITLE
Mark wheel as not compatible with python2

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -1,2 +1,0 @@
-[bdist_wheel]
-universal = 1


### PR DESCRIPTION
per https://wheel.readthedocs.io/en/stable/quickstart.html