### PR TITLE
.pre-commit-config.yaml: Remove duplicate checks

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -46,7 +46,7 @@ repos:
       - id: detect-private-key
         exclude: ^README.rst|(?:tests/)/
 
-  - repo: git://github.com/Lucas-C/pre-commit-hooks-markup
+  - repo: https://github.com/Lucas-C/pre-commit-hooks-markup
     rev: v1.0.1
     hooks:
       - id: rst-linter

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -19,7 +19,7 @@ repos:
       - id: isort
         args: ["--profile", "black"]
   - repo: https://github.com/psf/black
-    rev: "22.1.0"
+    rev: "22.3.0"
     hooks:
       - id: black
         language_version: python3 # Should be a command that runs python3.7+

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -32,16 +32,14 @@ repos:
       - id: requirements-txt-fixer
       - id: trailing-whitespace
         types: [python]
+      - id: check-added-large-files
       - id: check-case-conflict
-      - id: check-json
-      - id: check-xml
       - id: check-executables-have-shebangs
+      - id: check-json
+      - id: check-symlinks
       - id: check-toml
       - id: check-xml
       - id: check-yaml
-      - id: debug-statements
-      - id: check-added-large-files
-      - id: check-symlinks
       - id: debug-statements
       - id: detect-aws-credentials
         args: ["--allow-missing-credentials"]


### PR DESCRIPTION
Continues from #274 ... Sorting the checks reduces the chance of duplicates like `check-xml` and `debug-statements`.