### PR TITLE
Add Django 4.2 and Python 3.11 testing

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,28 +12,26 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: ["3.7", "3.8", "3.9", "3.10"]
-        django-version: ["2.2", "3.2", "4.0", "4.1"]
-        exclude:
-          - python-version: "3.10"
-            django-version: "2.2"
-          - python-version: "3.7"
-            django-version: "4.0"
-          - python-version: "3.7"
-            django-version: "4.1"
-
+        python: ["3.8", "3.9", "3.10", "3.11"]
     steps:
-      - uses: actions/checkout@v2
-      - uses: actions/setup-python@v2
+      - uses: actions/checkout@v4
         with:
-          python-version: ${{ matrix.python-version }}
+          fetch-depth: 0
+      - uses: actions/setup-python@v4
+        with:
+          python-version: ${{ matrix.python }}
           cache: "pip"
-      - run: pip install -r requirements.txt
-      - run: tox
-        env:
-          PYTHON_VER: ${{ matrix.python-version }}
-          DJANGO: ${{ matrix.django-version }}
-      # - run: coveralls
+
+      - name: Install Tox
+        run: |
+          python -m pip install --upgrade pip setuptools wheel
+          python -m pip install --upgrade tox tox-gh-actions
+
+      - name: Run test suite
+        run: tox
+
+      # - name: Upload coverage to Coveralls
+      #   run: coveralls
       #   env:
       #     GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       #     COVERALLS_REPO_TOKEN: ${{ secrets.COVERALLS_REPO_TOKEN }}

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -8,7 +8,7 @@ repos:
     rev: "v2.34.0"
     hooks:
       - id: pyupgrade
-        args: ["--py37-plus", "--keep-mock"]
+        args: ["--py38-plus", "--keep-mock"]
   - repo: https://github.com/asottile/yesqa
     rev: v1.3.0
     hooks:

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -3,11 +3,10 @@ Changelog
 
 Unreleased
 ----------
-
-Nothing new yet!
-
-#. Added testing for Django 4.1
-#. Dropped support for Python 3.7
+#. Added support for Django 4.1 and 4.2
+#. Removed support for Django 4.0 and 2.2
+#. Removed support for Python 3.7
+#. Added support for Python 3.11
 
 3.0.0 (2022-02-07)
 --------------------

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -7,6 +7,7 @@ Unreleased
 Nothing new yet!
 
 #. Added testing for Django 4.1
+#. Dropped support for Python 3.7
 
 3.0.0 (2022-02-07)
 --------------------

--- a/README.rst
+++ b/README.rst
@@ -24,8 +24,8 @@ Requirements
 
 Tested with:
 
-* Python: 3.7, 3.8, 3.9, 3.10
-* Django: 2.2, 3.2, 4.0
+* Python: 3.8, 3.9, 3.10, 3.11
+* Django: 3.2, 4.1, 4.2
 * You can view the `Python-Django support matrix here <https://docs.djangoproject.com/en/dev/faq/install/#what-python-version-can-i-use-with-django>`_
 
 This package only supports modern, “evergreen” desktop and mobile browsers. For IE11 support, make sure to add a `polyfill for Element.closest <https://developer.mozilla.org/en-US/docs/Web/API/Element/closest#Polyfill>`_.

--- a/setup.py
+++ b/setup.py
@@ -39,7 +39,6 @@ setup(
         "Programming Language :: Python",
         "Topic :: Internet :: WWW/HTTP :: Dynamic Content",
         "Programming Language :: Python :: 3",
-        "Programming Language :: Python :: 3.7",
         "Programming Language :: Python :: 3.8",
         "Programming Language :: Python :: 3.9",
         "Programming Language :: Python :: 3.10",

--- a/tox.ini
+++ b/tox.ini
@@ -1,19 +1,17 @@
 [tox]
 envlist =
-    py{37,38,39}-django2.2,
-    py{37,38,39,310}-django3.2,
-    py{38,39,310}-django{4.0,4.1,main},
+    py{38,39,310}-django3.2,
+    py{38,39,310,311}-django{4.1,4.2},
 
 [testenv]
 deps =
-    django2.2: Django>=2.2,<3.0
-    django3.2: Django>=3.2,<3.3
-    django4.0: Django>=4.0,<4.1
-    django4.1: Django>=4.1,<4.2
+    django3.2: Django~=3.2
+    django4.1: Django~=4.1
+    django4.2: Django~=4.2
     djangomain: https://github.com/django/django/archive/main.tar.gz
     coverage
 commands =
-    django{2.2,3.2,4.0,4.1,main}: coverage run manage.py test
+    coverage run manage.py test {posargs: -v 2}
 
 [gh-actions]
 python =
@@ -21,11 +19,4 @@ python =
     3.8: py38
     3.9: py39
     3.10: py310
-
-[gh-actions:env]
-DJANGO =
-    2.2: django2.2
-    3.2: django3.2
-    4.0: django4.0
-    4.1: django4.1
-    main: djangomain
+    3.11: py311

--- a/tox.ini
+++ b/tox.ini
@@ -13,6 +13,10 @@ deps =
 commands =
     coverage run manage.py test {posargs: -v 2}
 
+; Testing against the latest development version of Django is a special case, we only want to run it if needed.
+[testenv:djangomain]
+envlist = py311-djangomain
+
 [gh-actions]
 python =
     3.7: py37


### PR DESCRIPTION
Remove Python 3.7, Django 2.2 and 4.0

Also reworked the Github actions CI matrix a bit with the intend to improve maintainability. See commit message for reasoning.

Most controversial change is not including the compatibility check with the current in-development Django. There is not guarantee on how stable it is and I'd rather not see it included by default in our testing matrix. I feel like CI errors that are caused by a bug in Django are something we would want to avoid, not something to ignore when it occurs.

If there is interest, I'd suggest we set up a separate job that periodically runs the tests against the in-development Django.