### PR TITLE
Fix invalid RST link

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -207,7 +207,7 @@ In the event the score does not meet the requirements, the field validation will
 reCAPTCHA V3 Action
 ~~~~~~~~~~~~~~~~~~~
 
-The V3 reCAPTCHA supports an [`action`](https://developers.google.com/recaptcha/docs/v3#actions) value that provides break-downs of actions and adaptive risk analysis.
+The V3 reCAPTCHA supports an `action <https://developers.google.com/recaptcha/docs/v3#actions>`_ value that provides break-downs of actions and adaptive risk analysis.
 
 To set the action value, pass it when instantiating the ReCaptcha widget. By default it is set to `form`.
 


### PR DESCRIPTION
Turns out 99afcd026a30de955c88ff765c310b28a81699b8 introduced a markdown link, which won't work as our readme is written in reStructuredText.

This PR fixes the link.

Since Markdown is much more common, I suggest we convert our reStructuredText documents to Markdown.